### PR TITLE
Closing any window quits the program

### DIFF
--- a/server/src/data.py
+++ b/server/src/data.py
@@ -87,6 +87,7 @@ class Data:
     mWindow = "motion"
     gWindow = "settings"
     hWindow = "help window"
+    windows = [vWindow, mWindow, gWindow, hWindow]
 
     # The trackbars for the server settings. openCV uses strings to retrieve the different trackbars.
     motionTrackbar = "motion threshold"
@@ -385,6 +386,7 @@ class Data:
         Displays the current captured image (the most recent) on the video window.
         @return:
         """
+        self.checkWindowsStatus()
 
         # displays the image, self.video, on the video window, self.vWindow
         cv2.imshow(self.vWindow, self.video)
@@ -496,6 +498,22 @@ class Data:
                 self.interestList.remove(toRemove)
         # Redraw self.video on vWindow.
         cv2.imshow(self.vWindow, self.video)
+	
+    def quit(self):
+        cv2.destroyAllWindows()
+        self.videoCapture.release()
+        sys.exit()
+
+    def checkWindowsStatus(self):
+        """
+        If any is closed, close all.
+        """
+        for window in self.windows:
+            if window != self.hWindow:
+                windowStatus = cv2.getWindowProperty(window, 0)
+                if windowStatus < 0:
+                    self.quit()
+
 
     def updateTrackbars(self, x):
         """
@@ -506,9 +524,7 @@ class Data:
 
         # If the quit trackbar is on 1, exit the program.
         if cv2.getTrackbarPos(self.quitTrackbar, self.gWindow) == 1:
-            cv2.destroyAllWindows()
-            self.videoCapture.release() # destroy the video capture separately
-            sys.exit()
+		self.quit()
 
         # facesEnabled, motionEnabled, and flipHorizontal should all be True if their
         # trackbars are set to 1, and False otherwise.

--- a/server/src/data.py
+++ b/server/src/data.py
@@ -387,7 +387,7 @@ class Data:
         @return:
         """
         self.checkWindowsStatus()
-
+        
         # displays the image, self.video, on the video window, self.vWindow
         cv2.imshow(self.vWindow, self.video)
 
@@ -498,15 +498,21 @@ class Data:
                 self.interestList.remove(toRemove)
         # Redraw self.video on vWindow.
         cv2.imshow(self.vWindow, self.video)
-	
+
     def quit(self):
+        """
+        Kills the server and destroys all open window instances
+        Video capture needs to be destroyed seperately by calling release
+        """
         cv2.destroyAllWindows()
         self.videoCapture.release()
         sys.exit()
-
+   
     def checkWindowsStatus(self):
         """
-        If any is closed, close all.
+        In the list of open window instances, check if any is closed using getWindowProperty()
+        This does not include the help window "hWindow". We do not want closing the help window to affect the running of the other windows.
+        If a window has been closed,getWindowProperty will return -1 and invoke quit
         """
         for window in self.windows:
             if window != self.hWindow:
@@ -524,7 +530,7 @@ class Data:
 
         # If the quit trackbar is on 1, exit the program.
         if cv2.getTrackbarPos(self.quitTrackbar, self.gWindow) == 1:
-		self.quit()
+            self.quit() 
 
         # facesEnabled, motionEnabled, and flipHorizontal should all be True if their
         # trackbars are set to 1, and False otherwise.

--- a/server/src/server.py
+++ b/server/src/server.py
@@ -109,6 +109,8 @@ class Server:
         Searches for motion in the video feed; puts the found motion in data.shellList (instances of Blob).
         @return: none
         """
+        
+        self.data.checkWindowsStatus()
 
         # Creates average, if it doesn't yet exist.
         if (self.data.average is None):


### PR DESCRIPTION
Bug: Program crashes instead of closing

	* Resolved: Needed to release camera before sys.exit()

Bug: All windows respond to clicking Close except Motion

	* Resolved: Found seperate instance of motion being called in server

Generally, changed the design from using keypressed to using windowStatus on each window. To make this possible, we have to use a list with all the windows created. Before each GUI update, we iterate through the list and if any is closed, we close everything and exit.